### PR TITLE
Fixed seeds and Lesson validation for :description

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -2,11 +2,11 @@ class Lesson < ApplicationRecord
   has_many :bookings
   belongs_to :user
 
-  validates :name, length: {minimum: 3}
+  validates :name, length: { minimum: 3 }
   validates :address, presence: true
   validates :cuisine_genre, presence: true
-  validates :description, length: {in: 10..175}
-  validates :lesson_length_minutes, numericality: {only_integer: true}
-  validates :fee, numericality: {only_integer: true}
-  validates :capacity, numericality: {only_integer: true}
+  validates :description, length: { in: 10..500 }
+  validates :lesson_length_minutes, numericality: { only_integer: true }
+  validates :fee, numericality: { only_integer: true }
+  validates :capacity, numericality: { only_integer: true }
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,10 +29,10 @@ end
     cuisine_genre: Faker::Food.ethnic_category,
     description: Faker::Food.description,
     capacity: Faker::Number.within(range: 1..120),
-    fee: Faker::Number.within(range: 0.5..125.0),
+    fee: Faker::Number.within(range: 0..125),
     lesson_length_minutes: Faker::Number.within(range: 45..120),
     user: users.sample
-    )
-  end
+  )
+end
 
-  puts "Finished!"
+puts "Finished!"


### PR DESCRIPTION
Problems to run `rails db:seed`, fixed below:
- Deleted the decimal numbers in the seeds. Since the validation is saying those numbers MUST be integers, they need to be whole numbers in order to work.
- The description was too long, so changed the length up to 500 characters.

Tested everything before pushing.