### PR TITLE
Simple form styling and restructure

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,27 +1,30 @@
-<h2>Sign up</h2>
+<div class="container my-5">
 
-<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name),
-  data: {turbo: false}) do |f| %>
+  <h2>Sign up</h2>
 
-  <%= f.error_notification %>
+  <p>Already have an account? <%= link_to "Login", new_user_session_path %></p>
+  <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name),
+    data: {turbo: false}) do |f| %>
 
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" }%>
-    <%= f.input :password,
-                required: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
-                required: true,
-                input_html: { autocomplete: "new-password" } %>
-  </div>
+    <%= f.error_notification %>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Sign up" %>
-  </div>
-<% end %>
+    <div class="form-inputs">
+      <%= f.input :email,
+                  required: true,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" }%>
+      <%= f.input :password,
+                  required: true,
+                  hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+                  input_html: { autocomplete: "new-password" } %>
+      <%= f.input :password_confirmation,
+                  required: true,
+                  input_html: { autocomplete: "new-password" } %>
+    </div>
 
-<%= render "devise/shared/links" %>
+    <div class="form-actions">
+      <%= f.button :submit, "Sign up", class: "btn btn-success" %>
+    </div>
+  <% end %>
+
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,23 +1,31 @@
-<h2>Log in</h2>
+<div class="container my-5">
 
-<%= simple_form_for(resource, as: resource_name, url: session_path(resource_name),
-  data: {turbo: false}) do |f| %>
+  <h2>Log in</h2>
 
-    <div class="form-inputs">
 
-    <%= f.input :email,
-                required: false,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-    <%= f.input :password,
-                required: false,
-                input_html: { autocomplete: "current-password" } %>
-    <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
-  </div>
+  <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name),
+    data: {turbo: false}) do |f| %>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
-  </div>
-<% end %>
+      <div class="form-inputs">
 
-<%= render "devise/shared/links" %>
+      <%= f.input :email,
+                  required: false,
+                  autofocus: true,
+                  input_html: { autocomplete: "email" } %>
+      <%= f.input :password,
+                  required: false,
+                  input_html: { autocomplete: "current-password" } %>
+      <div class= "d-flex">
+        <%= f.input :remember_me, as: :boolean if devise_mapping.rememberable? %>
+        <%= link_to "Forgot your password?", new_password_path(resource_name), class: "ms-5" %><br />
+      </div>
+    </div>
+
+    <div class="form-actions">
+      <%= f.button :submit, "Log in", class: "btn btn-success" %>
+    </div>
+  <% end %>
+
+  <p class="pt-3">Don't have an account? <%= link_to "Sign up", new_user_registration_path %></p>
+
+</div>


### PR DESCRIPTION
Changes: 
- Added some padding around the form
- Added text next to the login and signup options
- Moved the login and signup options right to the top of the form
<img width="1396" alt="Captura de Pantalla 2023-01-26 a las 9 08 42" src="https://user-images.githubusercontent.com/70474104/214722457-cc15cd54-2e79-4cb9-8ef6-4b1ea1af16c0.png">
<img width="1377" alt="Captura de Pantalla 2023-01-26 a las 9 10 20" src="https://user-images.githubusercontent.com/70474104/214722578-30ea0b88-ccbe-4d04-9b36-ba74d2dfb729.png">


