### PR TITLE
Add start_time and participants attributes to Bookings table

### DIFF
--- a/db/migrate/20230126110626_add_start_time_and_participants_to_bookings.rb
+++ b/db/migrate/20230126110626_add_start_time_and_participants_to_bookings.rb
@@ -1,0 +1,6 @@
+class AddStartTimeAndParticipantsToBookings < ActiveRecord::Migration[7.0]
+  def change
+    add_column :bookings, :start_time, :datetime
+    add_column :bookings, :participants, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_24_112622) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_26_110626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_24_112622) do
     t.datetime "start_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "start_time"
+    t.integer "participants"
     t.index ["lesson_id"], name: "index_bookings_on_lesson_id"
     t.index ["user_id"], name: "index_bookings_on_user_id"
   end


### PR DESCRIPTION
Created migration to add two new attributes to Bookings table: 
- start_time as datetime value
- participants as integer value