### PR TITLE
Set display grid for index lessons and made responsive

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -1,4 +1,24 @@
 // card in booking index
+.cards-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  img {
+    height: 200px;
+  }
+}
+
+@media (max-width: 992px) {
+  .cards-container {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 768px) {
+  .cards-container {
+    grid-template-columns: 1fr;
+  }
+}
+
 .timenotice {
   padding: 3px;
   & > p {
@@ -14,6 +34,8 @@
   border: solid 1px $lightgreen;
   background-color: $lightgreen;
 }
+
+
 
 
 // card in lesson index

--- a/app/views/lessons/_lesson_card.html.erb
+++ b/app/views/lessons/_lesson_card.html.erb
@@ -1,26 +1,22 @@
-<div class="container">
-  <div class="d-flex row">
-    <% @lessons.each do |lesson| %>
-      <div class="card m-2 pt-2" style="width: 18rem;">
-        <%= image_tag "https://source.unsplash.com/200x200/?food #{lesson.name}" %>
-        <%# <img src="https://source.unsplash.com/200x200/?food" class="card-img-top" alt="..."> %>
-        <div class="card-body position-relative">
-          <h4 class="card-title"><%= lesson.name %></h4>
-          <div class="lesson-tags">
-            <ul class="p-0 d-flex flex-wrap">
-              <li class="d-inline me-1 mb-1 tag"><i class="fa fa-solid fa fa-person me-1"></i> <%= lesson.capacity %></li>
-              <li class="d-inline me-1 mb-1 tag"><i class="fa-solid fa-utensils me-1"></i> <%= lesson.cuisine_genre %> food</li>
-              <li class="d-inline me-1 mb-1 tag"><i class="fa fa-solid fa fa-clock me-1"></i> <%= lesson.lesson_length_minutes %> min</li>
-            </ul>
-          </div>
-          <p class="card-text"><%= lesson.description[...60] %>[...]</p>
-          <div class="card-bottom d-flex justify-content-between align-items-center">
-            <h5 class="mb-0"><strong>$<%= lesson.fee %></strong> / person</h5>
-            <%= link_to 'DETAIL', lesson_path(lesson), class: "btn btn-maingreen" %>
-          </div>
-          <%# <a href="#" class="btn btn-primary my-2 position-absolute bottom-0 end-0">DETAIL</a> %>
+<div class="cards-container">
+  <% @lessons.each do |lesson| %>
+    <div class="card m-2">
+      <%= image_tag "https://source.unsplash.com/200x200/?food #{lesson.name}", class: "lesson-img"%>
+      <div class="card-body d-flex flex-column justify-content-between">
+        <h4 class="card-title"><%= lesson.name %></h4>
+        <div class="lesson-tags">
+          <ul class="p-0 d-flex flex-wrap">
+            <li class="d-inline me-1 mb-1 tag"><i class="fa fa-solid fa fa-person me-1"></i> <%= lesson.capacity %></li>
+            <li class="d-inline me-1 mb-1 tag"><i class="fa-solid fa-utensils me-1"></i> <%= lesson.cuisine_genre %> food</li>
+            <li class="d-inline me-1 mb-1 tag"><i class="fa fa-solid fa fa-clock me-1"></i> <%= lesson.lesson_length_minutes %> min</li>
+          </ul>
+        </div>
+        <p class="card-text"><%= lesson.description[...60] %>[...]</p>
+        <div class="card-bottom d-flex justify-content-between align-items-center">
+          <h5 class="mb-0"><strong>$<%= lesson.fee %></strong> / person</h5>
+          <%= link_to 'See details', lesson_path(lesson), class: "btn btn-success" %>
         </div>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/lessons/index.html.erb
+++ b/app/views/lessons/index.html.erb
@@ -1,15 +1,13 @@
 
-<div class="landing" style="height: 45vh; background-image: url(https://images.unsplash.com/photo-1556910109-a14b4226abff?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80); background-position: 30% 85%;">
+<div class="landing" style="height: 30vh; background-image: url(https://images.unsplash.com/photo-1556910109-a14b4226abff?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80); background-position: 30% 85%;">
   <div class="container landing-content">
     <h1>Local Lessons</h1>
-    <h5 class="p-2 mb-2 bg-success text-white text-center" style="width: 140px;"><%= @lessons.count %> <%= @lessons.count >= 2 ? "lessons" : "lesson" %></h5>
-    <p>Discover New Culinary classes around you</p>
-    <p>Find a new chef in yourself</p>
+    <h5 class="p-2 mb-2 bg-success text-white text-center" style="width: 140px;">
+    <%= pluralize(@lessons.count, 'lesson') %></h5>
   </div>
 </div>
 
 
 <div class="container my-5">
   <%= render "lessons/lesson_card" %>
-
 </div>


### PR DESCRIPTION
**⚠️ These changes must be checked and approved by Junsuke 🙏🙏**

- Changed the display of lessons index to grid
- Set breakpoints for different screen sizes
- To avoid having very tall cards, I reduced the height of the photos to 200px
- Deleted the extra container div inside the cards-container
- Added the pluralize method to refractor code
<img width="1361" alt="Captura de Pantalla 2023-01-29 a las 21 40 09" src="https://user-images.githubusercontent.com/70474104/215327067-690cd71d-0565-40c0-afb3-3e11aaa759b8.png">
<img width="800" alt="Captura de Pantalla 2023-01-29 a las 21 40 19" src="https://user-images.githubusercontent.com/70474104/215327068-cc411125-7339-4d49-9165-1febacdddbfb.png">
<img width="512" alt="Captura de Pantalla 2023-01-29 a las 21 41 02" src="https://user-images.githubusercontent.com/70474104/215327073-5664a4a4-2db7-46ce-bd6e-35f85fdc8292.png">
