### PR TITLE
added routes for lesson edit and delete with authorization

### DIFF
--- a/app/assets/stylesheets/components/_buttons.scss
+++ b/app/assets/stylesheets/components/_buttons.scss
@@ -2,3 +2,12 @@
   background-color: $green;
   color: #fff;
 }
+
+.btn-lightgreen {
+  background-color: $lightgreen;
+  color: black;
+  &:hover {
+    background-color: $green;
+    color: #fff;
+  }
+}

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -18,10 +18,12 @@ class LessonsController < ApplicationController
 
   def new
     @lesson = Lesson.new
+    authorize @lesson
   end
 
   def create
     @lesson = Lesson.new(lesson_params)
+    authorize @lesson
     if @lesson.save
       redirect_to lesson_path(@lesson)
     else
@@ -29,21 +31,24 @@ class LessonsController < ApplicationController
     end
   end
 
-  # def edit
-  # end
+  def edit
+    authorize @lesson
+  end
 
-  # def update
-  #   if @lesson.update(lesson_params)
-  #     redirect_to lesson_path(@lesson)
-  #   else
-  #     render :edit, status: :unprocessable_entity
-  #   end
-  # end
+  def update
+    authorize @lesson
+    if @lesson.update(lesson_params)
+      redirect_to lesson_path(@lesson)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
 
-  # def destroy
-  #   @lesson.destroy
-  #   redirect_to root_path, status: :see_other
-  # end
+  def destroy
+    authorize @lesson
+    @lesson.destroy
+    redirect_to my_lessons_lessons_path, status: :see_other
+  end
 
   private
 

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,5 +1,5 @@
 class Lesson < ApplicationRecord
-  has_many :bookings
+  has_many :bookings, dependent: :destroy
   belongs_to :user
 
   validates :name, length: { minimum: 3 }

--- a/app/policies/lesson_policy.rb
+++ b/app/policies/lesson_policy.rb
@@ -14,4 +14,24 @@ class LessonPolicy < ApplicationPolicy
   def my_lessons?
     true
   end
+
+  def new?
+    create?
+  end
+
+  def create?
+    true
+  end
+
+  def edit?
+    update?
+  end
+
+  def update?
+    return record.user == user
+  end
+
+  def destroy?
+    return record.user == user
+  end
 end

--- a/app/views/lessons/_action_buttons.html.erb
+++ b/app/views/lessons/_action_buttons.html.erb
@@ -1,0 +1,6 @@
+<% if policy(lesson).edit? %>
+  <div class="action_buttons d-flex justify-content-around align-items-center position-absolute top-0 left-0 p-3", style="width: 230px">
+    <%= link_to 'Edit', edit_lesson_path(lesson), class: "btn btn-lightgreen me-2", style: "width: 48%;"%>
+    <%= link_to 'Delete', lesson_path(lesson), data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}, class: "btn btn-lightgreen", style: "width: 48%;" %>
+  </div>
+<% end %>

--- a/app/views/lessons/_lesson_card.html.erb
+++ b/app/views/lessons/_lesson_card.html.erb
@@ -1,7 +1,9 @@
 <div class="cards-container">
   <% @lessons.each do |lesson| %>
-    <div class="card m-2">
-      <%= image_tag "https://source.unsplash.com/200x200/?food #{lesson.name}", class: "lesson-img"%>
+    <div class="card m-2 position-relative">
+      <%= image_tag "https://source.unsplash.com/200x200/?food #{lesson.name}", class: "lesson-img" %>
+      <%= render "lessons/action_buttons", lesson: lesson %>
+
       <div class="card-body d-flex flex-column justify-content-between">
         <h4 class="card-title"><%= lesson.name %></h4>
         <div class="lesson-tags">

--- a/app/views/lessons/edit.html.erb
+++ b/app/views/lessons/edit.html.erb
@@ -1,0 +1,1 @@
+<h1>Hello from lesson edit page</h1>

--- a/app/views/lessons/new.html.erb
+++ b/app/views/lessons/new.html.erb
@@ -1,0 +1,1 @@
+<h1>Hello from lesson new page</h1>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -22,7 +22,7 @@
             <%= link_to "My bookings", bookings_path, class: "nav-link me-4" %>
           </li>
           <li class="nav-item">
-            <%= link_to "Create a lesson", "#", class: "nav-link me-4" %>
+            <%= link_to "Create a lesson", new_lesson_path, class: "nav-link me-4" %>
           </li>
           <li class="nav-item dropdown">
             <% if current_user.photo.attached? %>


### PR DESCRIPTION
I have added the links to create, edit and destroy the lesson. 
Edit and delete buttons on the lesson cards won't appear if the lesson was created by the other user.

Please check them and if it looks good, please accept to merge.
Thank you! 
![スクリーンショット 2023-01-31 12 57 16](https://user-images.githubusercontent.com/112766207/215660224-f4e3dddd-8ae4-44d2-84bb-d3cbe73c79b7.png)
![スクリーンショット 2023-01-31 12 57 34](https://user-images.githubusercontent.com/112766207/215660255-7e7ab08e-f839-47ee-9234-5d36f0734247.png)
