### PR TITLE
Add will_paginate gem and styles for lessons index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "devise"
 gem "pundit"
 gem "faker"
 gem "cloudinary"
+gem 'will_paginate', '~> 3.3'
 
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    will_paginate (3.3.1)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.6)
@@ -276,6 +277,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   x86_64-darwin-20
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -303,6 +305,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webdrivers
+  will_paginate (~> 3.3)
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -2,6 +2,7 @@
 .cards-container {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: 10px;
   img {
     height: 200px;
   }

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -8,3 +8,4 @@
 @import "cards";
 @import "landing";
 @import "buttons";
+@import "paginate";

--- a/app/assets/stylesheets/components/_paginate.scss
+++ b/app/assets/stylesheets/components/_paginate.scss
@@ -1,0 +1,34 @@
+.pagination {
+  margin-top: 10px;
+  cursor: pointer;
+
+  a, span, em {
+    padding: 0.2em 1em;
+    display: block;
+    margin-right: 10px;
+  }
+
+  .disabled {
+    color: #999999;
+    border: 1px solid #dddddd;
+  }
+
+  .current {
+    font-style: normal;
+    font-weight: bold;
+    background: $lightgreen;
+    color: white;
+    border: 1px solid $lightgreen;
+  }
+
+  a {
+    text-decoration: none;
+    color: $green;
+    border: 1px solid $lightgreen;
+    &:hover, &:focus {
+      color: #000033;
+      border-color: #000033;
+    }
+  }
+
+}

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -3,7 +3,7 @@ class LessonsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show my_lesson]
 
   def index
-    @lessons = policy_scope(Lesson).all
+    @lessons = policy_scope(Lesson).paginate(page: params[:page], per_page: 6)
   end
 
   def my_lessons

--- a/app/views/lessons/_lesson_card.html.erb
+++ b/app/views/lessons/_lesson_card.html.erb
@@ -1,6 +1,6 @@
 <div class="cards-container">
   <% @lessons.each do |lesson| %>
-    <div class="card m-2 position-relative">
+    <div class="card position-relative">
       <%= image_tag "https://source.unsplash.com/200x200/?food #{lesson.name}", class: "lesson-img" %>
       <%= render "lessons/action_buttons", lesson: lesson %>
 

--- a/app/views/lessons/index.html.erb
+++ b/app/views/lessons/index.html.erb
@@ -10,4 +10,5 @@
 
 <div class="container my-5">
   <%= render "lessons/lesson_card" %>
+  <%= will_paginate @lessons %>
 </div>


### PR DESCRIPTION
Changes:
- Added will_paginate gem to divide index page into pages (set it for 6 lessons per page)
- Added basic styles for the pagination
- Deleted the margin around each card and added a grid-gap instead to align everything

<img width="1372" alt="Captura de Pantalla 2023-01-31 a las 16 01 27" src="https://user-images.githubusercontent.com/70474104/215689369-93a42e6c-9062-4884-931b-85e4de9dbe20.png">
