### PR TITLE
Fixing small details

### DIFF
--- a/app/assets/stylesheets/components/_banner.scss
+++ b/app/assets/stylesheets/components/_banner.scss
@@ -1,5 +1,5 @@
 .banner {
-  padding: 100px 0px;
+  padding: 80px 0px;
   background-size: cover;
   background-position: bottom;
   display: flex;

--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -2,7 +2,7 @@
 .cards-container {
   display: grid;
   grid-template-columns: 1fr 1fr 1fr;
-  grid-gap: 10px;
+  grid-gap: 20px;
   img {
     height: 200px;
   }

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -38,3 +38,11 @@
     display: block;
   }
 }
+
+@media (max-width: 576px) {
+  .search {
+    padding: 0px 0px 10px 0px;
+    width: 100%;
+    display: block;
+  }
+}

--- a/app/assets/stylesheets/components/_tag.scss
+++ b/app/assets/stylesheets/components/_tag.scss
@@ -2,5 +2,11 @@
   font-size: 16px;
   padding: 5px 20px;
   border-radius: 50px;
-  background: rgb(225, 225, 225);
+  background: $lightgreen;
+}
+
+@media (max-width: 768px) {
+  .tag {
+    font-size: 14px;
+  }
 }

--- a/app/assets/stylesheets/config/_global.scss
+++ b/app/assets/stylesheets/config/_global.scss
@@ -1,8 +1,3 @@
-
-body {
-  height: 100vh;
-}
-
 ul {
   list-style: none;
   padding: 0px;
@@ -22,14 +17,8 @@ img {
   margin-top: 75px;
 }
 
-@media(max-width: 768px) {
-  .margin-top {
-    margin-top: 105px;
-  }
-}
-
 @media(max-width: 576px) {
   .margin-top {
-    margin-top: 160px;
+    margin-top: 150px;
   }
 }

--- a/app/assets/stylesheets/pages/_lessons_show.scss
+++ b/app/assets/stylesheets/pages/_lessons_show.scss
@@ -1,3 +1,16 @@
+
+.lesson-info {
+  margin-left: 20px;
+}
+
+@media(max-width: 768px) {
+  .lesson-info {
+    margin: 10px 0px;
+  }
+}
+
+
+// GRID CODE
 .photos-container {
   height: 400px;
   display: grid;

--- a/app/views/lessons/_lesson_card.html.erb
+++ b/app/views/lessons/_lesson_card.html.erb
@@ -21,8 +21,8 @@
             </div>
             <p class="card-text"><%= lesson.description[...60] %>[...]</p>
             <div class="card-bottom d-flex justify-content-between align-items-center">
-              <h5 class="mb-0"><strong>$<%= lesson.fee %></strong> / person</h5>
-              <%= link_to 'See details', lesson_path(lesson), class: "btn btn-success" %>
+              <h5 class="mb-0"><strong>$<%= lesson.fee %></strong> / <i class="fa fa-solid fa fa-person me-1"></i></h5>
+              <%= link_to 'See details', lesson_path(lesson), class: "btn btn-success w-75" %>
             </div>
           </div>
         </div>

--- a/app/views/lessons/index.html.erb
+++ b/app/views/lessons/index.html.erb
@@ -1,6 +1,6 @@
 <div class="margin-top">
-  <div class="landing" style="height: 30vh; background-image: url(https://images.unsplash.com/photo-1556910109-a14b4226abff?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80); background-position: 30% 85%;">
-    <div class="container landing-content">
+  <div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.2),rgba(0,0,0,0.2)), url(https://images.unsplash.com/photo-1556910109-a14b4226abff?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80); background-position: 30% 85%;">
+    <div class="container banner-content">
       <h1>List of Local Lessons</h1>
       <h5 class="p-2 mb-2 bg-success text-white text-center" style="width: 140px;">
       <%= pluralize(@lessons.count - @lessons.where(user: current_user).count, 'lesson') %></h5>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -1,94 +1,91 @@
 <div class="margin-top">
-
-  <div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0.4),rgba(0,0,0,0.4)), url(https://images.unsplash.com/photo-1556910109-a14b4226abff?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80); background-position: 30% 85%;">
+  <div class="banner" style="background-image: url(https://images.unsplash.com/photo-1556910109-a14b4226abff?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80); background-position: 30% 85%;">
   </div>
+</div>
 
-  <div class="container my-5">
-    <div class="row g-0">
-      <div class="col-md-4 me-3" style="width: 200px">
-        <% if @lesson.photo.attached? %>
-          <%= cl_image_tag @lesson.photo.key, class: "lesson-img" %>
-        <% elsif @lesson.main_photo %>
-          <%= image_tag "#{@lesson.main_photo}", class: "lesson-img" %>
-        <% end %>
+<div class="container my-5">
+  <div class="row">
+    <div class="col-md-4 me-3" style="width: 200px">
+      <% if @lesson.photo.attached? %>
+        <%= cl_image_tag @lesson.photo.key, class: "lesson-img" %>
+      <% elsif @lesson.main_photo %>
+        <%= image_tag "#{@lesson.main_photo}", class: "lesson-img" %>
+      <% end %>
+    </div>
+    <div class="col-md-8 lesson-info">
+      <h1><%= @lesson.name %></h1>
+      <div class="p-0 d-flex flex-wrap">
+        <p class="d-inline me-3 tag"><i class="fa fa-solid fa fa-person me-2"></i> <%= @lesson.capacity %></p>
+        <p class="d-inline me-3 tag"><i class="fa-solid fa-utensils me-2"></i> <%= @lesson.cuisine_genre %> food</p>
+        <p class="d-inline me-3 tag"><i class="fa fa-solid fa fa-clock me-2"></i> <%= @lesson.lesson_length_minutes %> min</p>
       </div>
-      <div class="col-md-8 ms-3">
-        <h1><%= @lesson.name %></h1>
-        <ul class="p-0">
-          <li class="d-inline me-3 tag"><i class="fa fa-solid fa fa-person me-2"></i> <%= @lesson.capacity %></li>
-          <li class="d-inline me-3 tag"><i class="fa-solid fa-utensils me-2"></i> <%= @lesson.cuisine_genre %> food</li>
-          <li class="d-inline me-3 tag"><i class="fa fa-solid fa fa-clock me-2"></i> <%= @lesson.lesson_length_minutes %> min</li>
-        </ul>
-        <p><%= @lesson.description %></p>
-      </div>
-  </div>
-    <hr class="mt-5">
-
-    <section class="row mt-5">
-      <div class="col-12 col-lg-6 d-flex flex-column">
-        <div class="d-flex align-items-center">
-          <%= image_tag('person_02.jpg', class: "avatar-large")  %>
-          <div class="ms-3">
-            <p class="fw-bold m-0">Host: <%= @lesson.user.first_name %></p>
-            <p class="m-0"><%= @lesson.user.lessons.count %> Verified lessons</p>
-          </div>
-        </div>
-        <div class="my-3">
-          <p>About me: I am excited to share with you my recipe. I have been cooking this dish for almost 10 years. This recipe has been passed down from my grandmother</p>
-          <p>I love cooking this dish, and I am really glad to meet you. I would love to welcome individuals with open mind and share their story with me.</p>
-        </div>
-      </div>
-
-      <div class="col-12 col-lg-6 bg-white p-4 rounded shadow-sm">
-        <h3>Book your lesson with <%= @lesson.user.first_name %>!</h3>
-        <% if user_signed_in? %>
-          <%= render 'lessons/booking_form' %>
-        <% else %>
-          <p>You need to <%= link_to "login", new_user_session_path, class: "form-link" %> to book your lesson</p>
-        <% end %>
-      </div>
-    </section>
-  </div>
-
-  <div class="section bg-white py-5">
-    <div class="container">
-      <section class="row">
-        <div class="col-12 col-md-4">
-          <h2 class="mb-4">Location</h2>
-          <p class="fw-bold"><%= @lesson.address %></p>
-          <ul class="p-0">
-            <p class="mb-1">Access Instructions:</p>
-            <li class="mb-1">From the station exit the north gates and head up the hill. </li>
-            <li class="mb-1">After walking for 5 minutes you will see a children's park with a giant tree. It has a panda toy. Turn right towards the east, in front of the park. </li>
-            <li class="mb-1">Along the road you will see big trees, they are pretty in spring with blossoms. About 5 mins you will see brown house made of bricks.</li>
-            <li class="mb-1">There will be a red door with flowers hanging from the door handle.</li>
-          </ul>
-        </div>
-
-        <div class="col-12 col-md-8">
-          <%= image_tag('map.png') %>
-        </div>
-      </section>
+      <p><%= @lesson.description %></p>
     </div>
   </div>
+  <hr class="mt-3">
 
-
-  <div class="container my-5">
-    <section class="mt-5">
-      <h2 class="mb-4">Photos from past lessons</h2>
-      <div class="photos-container">
-        <div class="div1" style="background-image: url(https://images.unsplash.com/photo-1589047133531-570405874c6a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80)">
-        </div>
-        <div class="div2" style="background-image: url(https://images.unsplash.com/photo-1570604127008-f644337cfb8b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80)">
-        </div>
-        <div class="div3" style="background-image: url(https://images.unsplash.com/photo-1589047133481-02b4a5327d89?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80)">
-        </div>
-        <div class="div4" style="background-image: url(https://images.unsplash.com/photo-1612432524941-5afe13fa63d4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2231&q=80)">
-        </div>
-        <div class="div5" style="background-image: url(https://images.unsplash.com/photo-1589047133531-570405874c6a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80)">
+  <section class="row mt-5">
+    <div class="col-12 col-lg-6 d-flex flex-column">
+      <div class="d-flex align-items-center">
+        <%= image_tag('person_02.jpg', class: "avatar-large")  %>
+        <div class="ms-3">
+          <p class="fw-bold m-0">Host: <%= @lesson.user.first_name %></p>
+          <p class="m-0"><%= @lesson.user.lessons.count %> Verified lessons</p>
         </div>
       </div>
-    </section>
+      <div class="my-3">
+        <p>About me: I am excited to share with you my recipe. I have been cooking this dish for almost 10 years. This recipe has been passed down from my grandmother</p>
+        <p>I love cooking this dish, and I am really glad to meet you. I would love to welcome individuals with open mind and share their story with me.</p>
+      </div>
+    </div>
 
+    <div class="col-12 col-lg-6 bg-white p-4 rounded shadow-sm">
+      <h3>Book your lesson with <%= @lesson.user.first_name %>!</h3>
+      <% if user_signed_in? %>
+        <%= render 'lessons/booking_form' %>
+      <% else %>
+        <p>You need to <%= link_to "login", new_user_session_path, class: "form-link" %> to book your lesson</p>
+      <% end %>
+    </div>
+  </section>
+</div>
+
+<div class="section bg-white py-5">
+  <div class="container">
+    <section class="row">
+      <div class="col-12 col-md-4">
+        <h2 class="mb-4">Location</h2>
+        <p class="fw-bold"><%= @lesson.address %></p>
+        <ul class="p-0">
+          <p class="mb-1">Access Instructions:</p>
+          <li class="mb-1">From the station exit the north gates and head up the hill. </li>
+          <li class="mb-1">After walking for 5 minutes you will see a children's park with a giant tree. It has a panda toy. Turn right towards the east, in front of the park. </li>
+          <li class="mb-1">Along the road you will see big trees, they are pretty in spring with blossoms. About 5 mins you will see brown house made of bricks.</li>
+          <li class="mb-1">There will be a red door with flowers hanging from the door handle.</li>
+        </ul>
+      </div>
+
+      <div class="col-12 col-md-8">
+        <%= image_tag('map.png') %>
+      </div>
+    </section>
   </div>
+</div>
+
+<div class="container my-5">
+  <section class="mt-5">
+    <h2 class="mb-4">Photos from past lessons</h2>
+    <div class="photos-container">
+      <div class="div1" style="background-image: url(https://images.unsplash.com/photo-1589047133531-570405874c6a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80)">
+      </div>
+      <div class="div2" style="background-image: url(https://images.unsplash.com/photo-1570604127008-f644337cfb8b?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80)">
+      </div>
+      <div class="div3" style="background-image: url(https://images.unsplash.com/photo-1589047133481-02b4a5327d89?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=774&q=80)">
+      </div>
+      <div class="div4" style="background-image: url(https://images.unsplash.com/photo-1612432524941-5afe13fa63d4?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=2231&q=80)">
+      </div>
+      <div class="div5" style="background-image: url(https://images.unsplash.com/photo-1589047133531-570405874c6a?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1770&q=80)">
+      </div>
+    </div>
+  </section>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,7 +71,7 @@ Lesson.create(
 )
 
 Lesson.create(
-  name: "大根まるごと一本使うミルフィーユ鍋！ レシピ・作り方",
+  name: "大根まるごと一本使うミルフィーユ鍋",
   address: "2-19 Matsugaya, Taito, Tokyo 111-0036 Taito",
   cuisine_genre: "Japanese",
   description: "簡単なのに華やか！旬のみずみずしい大根を美味しくたくさん食べられます！スライス大根なので辛味がなくお子さまも安心して召し上がれます！",


### PR DESCRIPTION
Changes:
- Deleted the margin left on the search bar in small screens. Now everything is aligned.
- Increased the gap between cards in the lessons index
- Increased the size of the "Details" buttons in each card
- Added padding to the bottom of some pages
- Changed the tags' color in the show page to our $lightgreen and made them smaller in smaller screens.


<img width="382" alt="Captura de Pantalla 2023-02-03 a las 11 22 16" src="https://user-images.githubusercontent.com/70474104/216497234-afdff818-fa00-43f7-9d50-f6a3d4bc2a94.png">
<img width="1072" alt="Captura de Pantalla 2023-02-03 a las 11 22 43" src="https://user-images.githubusercontent.com/70474104/216497298-9a2cd336-5246-41e4-bee0-b7629089108c.png">
<img width="366" alt="Captura de Pantalla 2023-02-03 a las 11 23 43" src="https://user-images.githubusercontent.com/70474104/216497462-6950e4cb-3743-42cf-937d-602ceda238b6.png">
